### PR TITLE
Fix Astro markdown processor deprecation warning

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,4 +1,5 @@
 import { defineConfig } from 'astro/config';
+import { unified } from '@astrojs/markdown-remark';
 import remarkBreaks from 'remark-breaks';
 import { rehypeCindorCodeBlocks } from './src/lib/astro-markdown/rehypeCindorCodeBlocks.mjs';
 import { remarkLegacyContainers } from './src/lib/astro-markdown/remarkLegacyContainers.mjs';
@@ -7,7 +8,9 @@ export default defineConfig({
 	output: 'static',
 	markdown: {
 		syntaxHighlight: false,
-		remarkPlugins: [remarkBreaks, remarkLegacyContainers],
-		rehypePlugins: [rehypeCindorCodeBlocks],
+		processor: unified({
+			remarkPlugins: [remarkBreaks, remarkLegacyContainers],
+			rehypePlugins: [rehypeCindorCodeBlocks],
+		}),
 	},
 });


### PR DESCRIPTION
## Summary
- switch Astro markdown config to the supported `markdown.processor: unified({...})` path
- remove the build-time markdown plugin deprecation warning

## Why
The previous config used deprecated `markdown.remarkPlugins` and `markdown.rehypePlugins` keys. Astro now recommends configuring these through `@astrojs/markdown-remark`'s `unified({...})` processor instead.

## Verification
- npm test
- npm run build

## Notes
- This is intentionally separate from merged PR #41
- No content or route output changes are intended
