### PR TITLE
Target paragraph line breaks in markdown content

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -335,7 +335,7 @@ img {
 	max-width: 100%;
 }
 
-.markdown-content br + br {
+.markdown-content p br {
 	display: block;
 	margin-top: 0.85rem;
 	content: '';


### PR DESCRIPTION
## Summary

- target legacy line-break spacing on `.markdown-content p br`, which matches the actual rendered posts

## Verification

- npm run build
