### PR TITLE
Normalize legacy prose hard breaks

### DIFF
--- a/src/astro-markdown-plugins.test.js
+++ b/src/astro-markdown-plugins.test.js
@@ -1,6 +1,12 @@
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
 import { describe, expect, test } from 'vitest';
 import { convertPreCodeElement } from './lib/astro-markdown/rehypeCindorCodeBlocks.mjs';
-import { parseLegacyMarkdownBlock } from './lib/astro-markdown/remarkLegacyContainers.mjs';
+import {
+	isLegacyProseBreakParagraph,
+	parseLegacyMarkdownBlock,
+	remarkLegacyContainers,
+} from './lib/astro-markdown/remarkLegacyContainers.mjs';
 
 describe('legacy markdown Astro plugins', () => {
 	test('converts footer-note blocks into wrapped markdown content', () => {
@@ -62,5 +68,31 @@ describe('legacy markdown Astro plugins', () => {
 				},
 			],
 		});
+	});
+
+	test('detects long prose hard-break paragraphs but leaves short intentional breaks alone', () => {
+		const proseTree = unified()
+			.use(remarkParse)
+			.parse(
+				`This is a long legacy prose line that should become its own paragraph once the migration cleanup runs because it is clearly body copy and not a short subtitle.  \nThis is another long prose line that should also become its own paragraph because it continues the article in the same old convert-breaks style.`,
+			);
+		const shortTree = unified().use(remarkParse).parse('**You Are 35% Normal**  \n*(Occasionally Normal)*');
+
+		expect(isLegacyProseBreakParagraph(proseTree.children[0])).toBe(true);
+		expect(isLegacyProseBreakParagraph(shortTree.children[0])).toBe(false);
+	});
+
+	test('rewrites long hard-break prose into multiple paragraph nodes', () => {
+		const tree = unified()
+			.use(remarkParse)
+			.parse(
+				`This is a long legacy prose line that should become its own paragraph once the migration cleanup runs because it is clearly body copy and not a short subtitle.  \nThis is another long prose line that should also become its own paragraph because it continues the article in the same old convert-breaks style.`,
+			);
+
+		remarkLegacyContainers()(tree, { value: '' });
+
+		expect(tree.children).toHaveLength(2);
+		expect(tree.children.every((node) => node.type === 'paragraph')).toBe(true);
+		expect(tree.children.some((node) => node.children.some((child) => child.type === 'break'))).toBe(false);
 	});
 });

--- a/src/lib/astro-markdown/remarkLegacyContainers.mjs
+++ b/src/lib/astro-markdown/remarkLegacyContainers.mjs
@@ -72,6 +72,91 @@ const parseLegacyMarkdownBlock = (source) => {
 	return null;
 };
 
+const splitChildrenOnBreaks = (children = []) => {
+	const segments = [];
+	let currentSegment = [];
+
+	for (const child of children) {
+		if (child.type === 'break') {
+			segments.push(currentSegment);
+			currentSegment = [];
+			continue;
+		}
+
+		currentSegment.push(child);
+	}
+
+	segments.push(currentSegment);
+
+	return segments.filter((segment) => segment.length > 0);
+};
+
+const getTextFromNode = (node) => {
+	if (!node) {
+		return '';
+	}
+
+	if (typeof node.value === 'string') {
+		return node.value;
+	}
+
+	if (Array.isArray(node.children)) {
+		return node.children.map(getTextFromNode).join('');
+	}
+
+	return '';
+};
+
+const getSegmentText = (segment) =>
+	segment
+		.map(getTextFromNode)
+		.join('')
+		.replace(/\s+/g, ' ')
+		.trim();
+
+const isLegacyProseBreakParagraph = (node) => {
+	const breakCount = node.children.filter((child) => child.type === 'break').length;
+
+	if (breakCount === 0) {
+		return false;
+	}
+
+	const segments = splitChildrenOnBreaks(node.children);
+
+	if (segments.length < 2) {
+		return false;
+	}
+
+	const segmentTexts = segments.map(getSegmentText).filter(Boolean);
+
+	if (segmentTexts.length !== segments.length) {
+		return false;
+	}
+
+	const totalLength = segmentTexts.reduce((sum, text) => sum + text.length, 0);
+
+	return breakCount >= 2 || (segmentTexts.every((text) => text.length >= 48) && totalLength >= 160);
+};
+
+const expandLegacyProseBreakParagraphs = (tree) => {
+	visit(tree, 'paragraph', (node, index, parent) => {
+		if (!parent || typeof index !== 'number' || !isLegacyProseBreakParagraph(node)) {
+			return;
+		}
+
+		const segments = splitChildrenOnBreaks(node.children);
+
+		parent.children.splice(
+			index,
+			1,
+			...segments.map((segment) => ({
+				type: 'paragraph',
+				children: segment,
+			})),
+		);
+	});
+};
+
 const transformLegacyMarkdownBlocks = (tree, source) => {
 	visit(tree, 'paragraph', (node, index, parent) => {
 		if (!parent || typeof index !== 'number') {
@@ -96,11 +181,16 @@ const transformLegacyMarkdownBlocks = (tree, source) => {
 
 const remarkLegacyContainers = () => (tree, file) => {
 	transformLegacyMarkdownBlocks(tree, String(file.value ?? ''));
+	expandLegacyProseBreakParagraphs(tree);
 };
 
 export {
 	YOUTUBE_EMBED_ATTRIBUTES,
+	expandLegacyProseBreakParagraphs,
+	getSegmentText,
+	isLegacyProseBreakParagraph,
 	parseLegacyMarkdownBlock,
 	remarkLegacyContainers,
+	splitChildrenOnBreaks,
 	transformLegacyMarkdownBlocks,
 };

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -335,12 +335,6 @@ img {
 	max-width: 100%;
 }
 
-.markdown-content p br {
-	display: block;
-	margin-top: 0.85rem;
-	content: '';
-}
-
 .markdown-content li + li {
 	margin-top: 0.5rem;
 }


### PR DESCRIPTION
## Summary

- stop styling paragraph `<br>` tags directly
- normalize legacy prose hard-break paragraphs into real paragraphs in the markdown pipeline
- keep short intentional hard breaks, like title/subtitle pairs, unchanged

## Verification

- npm test -- --run src/astro-markdown-plugins.test.js
- npm run build
- confirmed `sick_today` no longer renders `<br>` in the prose paragraph while `how_normal_are_you` still keeps its short intentional break
