### PR TITLE
Split legacy prose paragraphs by source lines

### DIFF
--- a/src/astro-markdown-plugins.test.js
+++ b/src/astro-markdown-plugins.test.js
@@ -3,6 +3,7 @@ import remarkParse from 'remark-parse';
 import { describe, expect, test } from 'vitest';
 import { convertPreCodeElement } from './lib/astro-markdown/rehypeCindorCodeBlocks.mjs';
 import {
+	isLegacySourceLineParagraph,
 	isLegacyProseBreakParagraph,
 	parseLegacyMarkdownBlock,
 	remarkLegacyContainers,
@@ -92,6 +93,28 @@ describe('legacy markdown Astro plugins', () => {
 		remarkLegacyContainers()(tree, { value: '' });
 
 		expect(tree.children).toHaveLength(2);
+		expect(tree.children.every((node) => node.type === 'paragraph')).toBe(true);
+		expect(tree.children.some((node) => node.children.some((child) => child.type === 'break'))).toBe(false);
+	});
+
+	test('detects long source-line legacy prose paragraphs', () => {
+		const source = `First long legacy prose line that should become its own paragraph because this old content was saved as wrapped lines rather than true paragraph blocks.
+Second long legacy prose line that should also become its own paragraph because it clearly continues the article body in the same wrapped style.
+Third long legacy prose line finishes the thought and keeps the total content well beyond the threshold for prose normalization.`;
+
+		expect(isLegacySourceLineParagraph(source)).toBe(true);
+		expect(isLegacySourceLineParagraph('**You Are 35% Normal**  \n*(Occasionally Normal)*')).toBe(false);
+	});
+
+	test('rewrites long source-line prose into multiple paragraph nodes', () => {
+		const source = `First long legacy prose line that should become its own paragraph because this old content was saved as wrapped lines rather than true paragraph blocks.
+Second long legacy prose line that should also become its own paragraph because it clearly continues the article body in the same wrapped style.
+Third long legacy prose line finishes the thought and keeps the total content well beyond the threshold for prose normalization.`;
+		const tree = unified().use(remarkParse).parse(source);
+
+		remarkLegacyContainers()(tree, { value: source });
+
+		expect(tree.children).toHaveLength(3);
 		expect(tree.children.every((node) => node.type === 'paragraph')).toBe(true);
 		expect(tree.children.some((node) => node.children.some((child) => child.type === 'break'))).toBe(false);
 	});

--- a/src/lib/astro-markdown/remarkLegacyContainers.mjs
+++ b/src/lib/astro-markdown/remarkLegacyContainers.mjs
@@ -114,6 +114,45 @@ const getSegmentText = (segment) =>
 		.replace(/\s+/g, ' ')
 		.trim();
 
+const getParagraphSourceLines = (nodeSource = '') =>
+	nodeSource
+		.split(/\r?\n/u)
+		.map((line) => line.replace(/\s+$/u, ''))
+		.filter((line) => line.trim().length > 0);
+
+const getLineText = (line = '') =>
+	line
+		.replace(/[*_`[\]<>]/g, '')
+		.replace(/\([^)]*\)/g, '')
+		.replace(/\s+/g, ' ')
+		.trim();
+
+const parseParagraphLineChildren = (line) => {
+	const parsedNodes = parseMarkdownFragment(line);
+	const paragraphNode = parsedNodes.find((node) => node.type === 'paragraph');
+
+	return paragraphNode?.children ?? [{ type: 'text', value: line }];
+};
+
+const isLegacySourceLineParagraph = (nodeSource) => {
+	const lines = getParagraphSourceLines(nodeSource);
+
+	if (lines.length < 2) {
+		return false;
+	}
+
+	const lineTexts = lines.map(getLineText).filter(Boolean);
+
+	if (lineTexts.length !== lines.length) {
+		return false;
+	}
+
+	const totalLength = lineTexts.reduce((sum, text) => sum + text.length, 0);
+	const longLineCount = lineTexts.filter((text) => text.length >= 48).length;
+
+	return totalLength >= 180 && (lines.length >= 3 || longLineCount === lines.length);
+};
+
 const isLegacyProseBreakParagraph = (node) => {
 	const breakCount = node.children.filter((child) => child.type === 'break').length;
 
@@ -138,9 +177,29 @@ const isLegacyProseBreakParagraph = (node) => {
 	return breakCount >= 2 || (segmentTexts.every((text) => text.length >= 48) && totalLength >= 160);
 };
 
-const expandLegacyProseBreakParagraphs = (tree) => {
+const expandLegacyProseBreakParagraphs = (tree, source) => {
 	visit(tree, 'paragraph', (node, index, parent) => {
-		if (!parent || typeof index !== 'number' || !isLegacyProseBreakParagraph(node)) {
+		if (!parent || typeof index !== 'number') {
+			return;
+		}
+
+		const nodeSource = getNodeSource(node, source);
+
+		if (nodeSource && isLegacySourceLineParagraph(nodeSource)) {
+			const lines = getParagraphSourceLines(nodeSource);
+
+			parent.children.splice(
+				index,
+				1,
+				...lines.map((line) => ({
+					type: 'paragraph',
+					children: parseParagraphLineChildren(line),
+				})),
+			);
+			return;
+		}
+
+		if (!isLegacyProseBreakParagraph(node)) {
 			return;
 		}
 
@@ -180,16 +239,21 @@ const transformLegacyMarkdownBlocks = (tree, source) => {
 };
 
 const remarkLegacyContainers = () => (tree, file) => {
-	transformLegacyMarkdownBlocks(tree, String(file.value ?? ''));
-	expandLegacyProseBreakParagraphs(tree);
+	const source = String(file.value ?? '');
+
+	transformLegacyMarkdownBlocks(tree, source);
+	expandLegacyProseBreakParagraphs(tree, source);
 };
 
 export {
 	YOUTUBE_EMBED_ATTRIBUTES,
 	expandLegacyProseBreakParagraphs,
 	getSegmentText,
+	getParagraphSourceLines,
+	isLegacySourceLineParagraph,
 	isLegacyProseBreakParagraph,
 	parseLegacyMarkdownBlock,
+	parseParagraphLineChildren,
 	remarkLegacyContainers,
 	splitChildrenOnBreaks,
 	transformLegacyMarkdownBlocks,


### PR DESCRIPTION
## Summary

- use original paragraph source lines, not only parsed break nodes, when normalizing legacy prose paragraphs
- fix wrapped legacy posts like `mackinac_vacation` that only had one markdown hard break but several raw source lines
- keep short intentional breaks like the quiz subtitle intact

## Verification

- npm test -- --run src/astro-markdown-plugins.test.js
- npm run build
- confirmed `mackinac_vacation` and `sick_today` render without `<br>` in prose, while `how_normal_are_you` still keeps its intentional `<br>`
