### PR TITLE
Split legacy prose on embedded newlines

### DIFF
--- a/src/astro-markdown-plugins.test.js
+++ b/src/astro-markdown-plugins.test.js
@@ -118,4 +118,19 @@ Third long legacy prose line finishes the thought and keeps the total content we
 		expect(tree.children.every((node) => node.type === 'paragraph')).toBe(true);
 		expect(tree.children.some((node) => node.children.some((child) => child.type === 'break'))).toBe(false);
 	});
+
+	test('rewrites paragraphs that mix one hard break with embedded newline text', () => {
+		const source = `First long legacy prose line that ends with a markdown hard break because that is how the exporter originally marked the first paragraph boundary.  
+Second long legacy prose line keeps going as plain wrapped source text without another explicit hard break.
+Third long legacy prose line still belongs as its own paragraph even though the parser leaves it inside the same text node.
+Fourth long legacy prose line finishes the block and should not remain trapped behind inline break markup.`;
+		const tree = unified().use(remarkParse).parse(source);
+
+		remarkLegacyContainers()(tree, { value: '' });
+
+		expect(tree.children).toHaveLength(4);
+		expect(tree.children.every((node) => node.type === 'paragraph')).toBe(true);
+		expect(tree.children.some((node) => node.children.some((child) => child.type === 'break'))).toBe(false);
+		expect(tree.children[1].children[0].value.startsWith('Second long legacy prose line')).toBe(true);
+	});
 });

--- a/src/lib/astro-markdown/remarkLegacyContainers.mjs
+++ b/src/lib/astro-markdown/remarkLegacyContainers.mjs
@@ -91,6 +91,49 @@ const splitChildrenOnBreaks = (children = []) => {
 	return segments.filter((segment) => segment.length > 0);
 };
 
+const splitChildrenOnLegacyBoundaries = (children = []) => {
+	const segments = [];
+	let currentSegment = [];
+
+	const pushSegment = () => {
+		if (currentSegment.length > 0) {
+			segments.push(currentSegment);
+			currentSegment = [];
+		}
+	};
+
+	for (const child of children) {
+		if (child.type === 'break') {
+			pushSegment();
+			continue;
+		}
+
+		if (child.type === 'text' && child.value.includes('\n')) {
+			const parts = child.value.split('\n');
+
+			parts.forEach((part, index) => {
+				if (part.length > 0) {
+					currentSegment.push({
+						...child,
+						value: part,
+					});
+				}
+
+				if (index < parts.length - 1) {
+					pushSegment();
+				}
+			});
+			continue;
+		}
+
+		currentSegment.push(child);
+	}
+
+	pushSegment();
+
+	return segments;
+};
+
 const getTextFromNode = (node) => {
 	if (!node) {
 		return '';
@@ -154,13 +197,7 @@ const isLegacySourceLineParagraph = (nodeSource) => {
 };
 
 const isLegacyProseBreakParagraph = (node) => {
-	const breakCount = node.children.filter((child) => child.type === 'break').length;
-
-	if (breakCount === 0) {
-		return false;
-	}
-
-	const segments = splitChildrenOnBreaks(node.children);
+	const segments = splitChildrenOnLegacyBoundaries(node.children);
 
 	if (segments.length < 2) {
 		return false;
@@ -174,7 +211,7 @@ const isLegacyProseBreakParagraph = (node) => {
 
 	const totalLength = segmentTexts.reduce((sum, text) => sum + text.length, 0);
 
-	return breakCount >= 2 || (segmentTexts.every((text) => text.length >= 48) && totalLength >= 160);
+	return segments.length >= 3 || (segmentTexts.every((text) => text.length >= 48) && totalLength >= 160);
 };
 
 const expandLegacyProseBreakParagraphs = (tree, source) => {
@@ -203,7 +240,7 @@ const expandLegacyProseBreakParagraphs = (tree, source) => {
 			return;
 		}
 
-		const segments = splitChildrenOnBreaks(node.children);
+		const segments = splitChildrenOnLegacyBoundaries(node.children);
 
 		parent.children.splice(
 			index,
@@ -255,6 +292,7 @@ export {
 	parseLegacyMarkdownBlock,
 	parseParagraphLineChildren,
 	remarkLegacyContainers,
+	splitChildrenOnLegacyBoundaries,
 	splitChildrenOnBreaks,
 	transformLegacyMarkdownBlocks,
 };


### PR DESCRIPTION
## Summary

- split legacy prose paragraphs on embedded newline text as well as explicit markdown break nodes
- fix pages like `mackinac_vacation` where only the first boundary became a `break` node but later paragraph boundaries remained embedded `\n` in text
- keep short intentional breaks like the quiz subtitle unchanged

## Verification

- npm test -- --run src/astro-markdown-plugins.test.js
- npm run build
- confirmed `mackinac_vacation` and `sick_today` render without prose `<br>`, while `how_normal_are_you` still keeps its intentional `<br>`
