### PR TITLE
Use Cindor search component for site search

### DIFF
--- a/src/cindor-register.js
+++ b/src/cindor-register.js
@@ -6,6 +6,7 @@ import { CindorLayoutContent } from 'cindor-ui-core/components/layout-content/ci
 import { CindorLayoutHeader } from 'cindor-ui-core/components/layout-header/cindor-layout-header';
 import { CindorLink } from 'cindor-ui-core/components/link/cindor-link';
 import { CindorProvider } from 'cindor-ui-core/components/provider/cindor-provider';
+import { CindorSearch } from 'cindor-ui-core/components/search/cindor-search';
 import { CindorStack } from 'cindor-ui-core/components/stack/cindor-stack';
 
 const definitions = [
@@ -17,6 +18,7 @@ const definitions = [
 	['cindor-layout-header', CindorLayoutHeader],
 	['cindor-link', CindorLink],
 	['cindor-provider', CindorProvider],
+	['cindor-search', CindorSearch],
 	['cindor-stack', CindorStack],
 ];
 

--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -1,19 +1,14 @@
 <div class="site-search" data-site-search>
-	<label class="site-search__label" for="site-search-input">Search posts</label>
-	<div class="site-search__control">
-		<input
-			id="site-search-input"
-			class="site-search__input"
-			type="search"
-			name="search"
-			placeholder="Search posts"
-			autocomplete="off"
-			spellcheck="false"
-			minlength="3"
-			data-site-search-input
-		/>
-		<span class="site-search__icon" aria-hidden="true">⌕</span>
-	</div>
+	<label id="site-search-input-label" class="site-search__label" for="site-search-input">Search posts</label>
+	<cindor-search
+		id="site-search-input"
+		class="site-search__input"
+		name="search"
+		placeholder="Search posts"
+		autocomplete="off"
+		data-site-search-input
+		aria-labelledby="site-search-input-label"
+	></cindor-search>
 	<div class="site-search__results" hidden data-site-search-results>
 		<p class="site-search__status" data-site-search-status></p>
 		<ul class="site-search__list" role="list" data-site-search-list></ul>
@@ -126,7 +121,7 @@
 		});
 
 		searchInput.addEventListener('input', (event) => {
-			runSearch(event.target.value);
+			runSearch(event.currentTarget.value);
 		});
 
 		searchInput.addEventListener('keydown', (event) => {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -101,35 +101,14 @@ img {
 	border: 0;
 }
 
-.site-search__control {
-	position: relative;
-}
-
 .site-search__input {
+	display: block;
 	inline-size: 100%;
 	min-inline-size: 13rem;
-	padding: 0.65rem 2.4rem 0.65rem 0.85rem;
-	border: 1px solid var(--border);
-	border-radius: 999px;
-	background: var(--surface);
-	color: var(--fg);
-	font: inherit;
-	line-height: 1.2;
-	box-sizing: border-box;
 }
 
-.site-search__input:focus-visible {
-	outline: none;
-	box-shadow: var(--ring-focus);
-}
-
-.site-search__icon {
-	position: absolute;
-	top: 50%;
-	right: 0.85rem;
-	transform: translateY(-50%);
-	color: var(--accent);
-	pointer-events: none;
+.site-search__input::part(surface) {
+	inline-size: 100%;
 }
 
 .site-search__results {


### PR DESCRIPTION
## Summary
- replace the raw site search input with the Cindor search component
- keep the existing search-index and result-list behavior intact
- trim the old custom input/icon CSS that the Cindor control now handles

## Testing
- npm run build
