### PR TITLE
Use Cindor register bundle and bump cindor-ui-core to 0.1.84

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "astro": "^6.4.8",
-        "cindor-ui-core": "^0.1.81",
+        "cindor-ui-core": "^0.1.84",
         "js-yaml": "^4.2.0",
         "remark-breaks": "^4.0.0"
       },
@@ -3753,9 +3753,9 @@
       }
     },
     "node_modules/cindor-ui-core": {
-      "version": "0.1.81",
-      "resolved": "https://registry.npmjs.org/cindor-ui-core/-/cindor-ui-core-0.1.81.tgz",
-      "integrity": "sha512-nb7k4RCgbLHllJWHlxnNDsCmNrj1ZcKhHT9UsGzmYWZ8vdavMSlmnb6EVcbBQAHQQO0R8cnvPfc06Am/NQHoOw==",
+      "version": "0.1.84",
+      "resolved": "https://registry.npmjs.org/cindor-ui-core/-/cindor-ui-core-0.1.84.tgz",
+      "integrity": "sha512-xP6tjSovDHAzvt4axXPfjB2cHGUinQlf6nqbyZex9p4eGL3SOWSJGL8Cc6h3LP3ySsNy70CxUvpyvpFv777t2A==",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",
         "highlight.js": "^11.11.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "astro": "^6.4.8",
-    "cindor-ui-core": "^0.1.81",
+    "cindor-ui-core": "^0.1.84",
     "js-yaml": "^4.2.0",
     "remark-breaks": "^4.0.0"
   },


### PR DESCRIPTION
## Summary
- switch CT4 from the local partial `src/cindor-register.js` shim to the upstream `cindor-ui-core/register` entrypoint
- bump `cindor-ui-core` from `^0.1.81` to `^0.1.84`
- remove the now-redundant local registration file

## Why
The upstream Cindor package now registers `cindor-icon`, but CT4 was still importing its own hand-maintained register file. That meant `cindor-search` upgraded while the nested `cindor-icon` stayed undefined, so the search SVG never rendered.

## Verification
- `npm test`
- `npm run build`
- real browser check against the built site confirming `customElements.get("cindor-icon")`, nested `shadowRoot`, and nested `svg` all exist