### PR TITLE
Fix markdown rendering in post previews

### DIFF
--- a/src/components/Excerpt.astro
+++ b/src/components/Excerpt.astro
@@ -8,7 +8,7 @@ import {
 
 const { entry } = Astro.props;
 const category = entry.categoryId ? getCategoryById(entry.categoryId) : null;
-const excerptPreview = getExcerptPreview(entry.excerpt);
+const excerptPreview = await getExcerptPreview(entry.excerpt);
 ---
 
 <article class="post-card">

--- a/src/lib/content.js
+++ b/src/lib/content.js
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { getCollection } from 'astro:content';
 import { cleanEntryBasename, getEntryPath } from './routes';
+import { getExcerptPreview } from './excerpt-preview';
 
 const CATEGORIES_PATH = path.join(process.cwd(), 'src', 'data', 'categories.json');
 
@@ -9,38 +10,6 @@ let cachedEntriesPromise;
 let cachedCategories;
 
 const sortEntries = (left, right) => left.sortOrder - right.sortOrder;
-
-const decodeHtmlEntities = (value) =>
-	value
-		.replace(/&nbsp;/gi, ' ')
-		.replace(/&amp;/gi, '&')
-		.replace(/&lt;/gi, '<')
-		.replace(/&gt;/gi, '>')
-		.replace(/&quot;/gi, '"')
-		.replace(/&#39;|&apos;/gi, "'");
-
-const stripHtml = (value = '') =>
-	decodeHtmlEntities(
-		String(value)
-			.replace(/<br\s*\/?>/gi, ' ')
-			.replace(/<\/p>|<\/div>|<\/li>|<\/h[1-6]>/gi, ' ')
-			.replace(/<[^>]+>/g, ' '),
-	)
-		.replace(/\s+/g, ' ')
-		.trim();
-
-const getExcerptPreview = (value = '', maxLength = 240) => {
-	const text = stripHtml(value);
-
-	if (!text || text.length <= maxLength) {
-		return text;
-	}
-
-	const shortened = text.slice(0, maxLength);
-	const boundaryIndex = shortened.lastIndexOf(' ');
-
-	return `${shortened.slice(0, boundaryIndex > 0 ? boundaryIndex : maxLength)}...`;
-};
 
 const formatShortDate = (createdOn) =>
 	new Date(createdOn).toLocaleDateString('en-us', {

--- a/src/lib/excerpt-preview.js
+++ b/src/lib/excerpt-preview.js
@@ -1,0 +1,56 @@
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkRehype from 'remark-rehype';
+import rehypeStringify from 'rehype-stringify';
+import { rehypeCindorCodeBlocks } from './astro-markdown/rehypeCindorCodeBlocks.mjs';
+import { remarkLegacyContainers } from './astro-markdown/remarkLegacyContainers.mjs';
+
+const decodeHtmlEntities = (value) =>
+	value
+		.replace(/&nbsp;/gi, ' ')
+		.replace(/&amp;/gi, '&')
+		.replace(/&lt;/gi, '<')
+		.replace(/&gt;/gi, '>')
+		.replace(/&quot;/gi, '"')
+		.replace(/&#39;|&apos;/gi, "'");
+
+const stripHtml = (value = '') =>
+	decodeHtmlEntities(
+		String(value)
+			.replace(/<br\s*\/?>/gi, ' ')
+			.replace(/<\/p>|<\/div>|<\/li>|<\/h[1-6]>/gi, ' ')
+			.replace(/<[^>]+>/g, ' '),
+	)
+		.replace(/\s+/g, ' ')
+		.trim();
+
+const renderMarkdownFragmentToHtml = async (value = '') => {
+	if (!value) {
+		return '';
+	}
+
+	const file = await unified()
+		.use(remarkParse)
+		.use(remarkLegacyContainers)
+		.use(remarkRehype)
+		.use(rehypeCindorCodeBlocks)
+		.use(rehypeStringify)
+		.process(value);
+
+	return String(file);
+};
+
+const getExcerptPreview = async (value = '', maxLength = 240) => {
+	const text = stripHtml(await renderMarkdownFragmentToHtml(value));
+
+	if (!text || text.length <= maxLength) {
+		return text;
+	}
+
+	const shortened = text.slice(0, maxLength);
+	const boundaryIndex = shortened.lastIndexOf(' ');
+
+	return `${shortened.slice(0, boundaryIndex > 0 ? boundaryIndex : maxLength)}...`;
+};
+
+export { getExcerptPreview };

--- a/src/lib/excerpt-preview.js
+++ b/src/lib/excerpt-preview.js
@@ -6,13 +6,12 @@ import { rehypeCindorCodeBlocks } from './astro-markdown/rehypeCindorCodeBlocks.
 import { remarkLegacyContainers } from './astro-markdown/remarkLegacyContainers.mjs';
 
 const decodeHtmlEntities = (value) =>
-	value
 		.replace(/&nbsp;/gi, ' ')
+		.replace(/&amp;/gi, '&')
 		.replace(/&lt;/gi, '<')
 		.replace(/&gt;/gi, '>')
 		.replace(/&quot;/gi, '"')
-		.replace(/&#39;|&apos;/gi, "'")
-		.replace(/&amp;/gi, '&');
+		.replace(/&#39;|&apos;/gi, "'");
 
 const stripHtml = (value = '') =>
 	decodeHtmlEntities(

--- a/src/lib/excerpt-preview.js
+++ b/src/lib/excerpt-preview.js
@@ -8,11 +8,11 @@ import { remarkLegacyContainers } from './astro-markdown/remarkLegacyContainers.
 const decodeHtmlEntities = (value) =>
 	value
 		.replace(/&nbsp;/gi, ' ')
-		.replace(/&amp;/gi, '&')
 		.replace(/&lt;/gi, '<')
 		.replace(/&gt;/gi, '>')
 		.replace(/&quot;/gi, '"')
-		.replace(/&#39;|&apos;/gi, "'");
+		.replace(/&#39;|&apos;/gi, "'")
+		.replace(/&amp;/gi, '&');
 
 const stripHtml = (value = '') =>
 	decodeHtmlEntities(

--- a/src/markdown-and-routing.test.js
+++ b/src/markdown-and-routing.test.js
@@ -7,6 +7,7 @@ import rehypeStringify from 'rehype-stringify';
 import { describe, expect, test } from 'vitest';
 import { rehypeCindorCodeBlocks } from './lib/astro-markdown/rehypeCindorCodeBlocks.mjs';
 import { remarkLegacyContainers } from './lib/astro-markdown/remarkLegacyContainers.mjs';
+import { getExcerptPreview } from './lib/excerpt-preview';
 import { cleanEntryBasename, getEntryPath } from './lib/routes';
 
 const POSTS_DIRECTORY = path.join(process.cwd(), 'content', 'posts');
@@ -88,6 +89,15 @@ describe('Astro markdown pipeline', () => {
 		expect(renderedHtml).toContain('<table>');
 		expect(renderedHtml).toContain('<th>Level</th>');
 		expect(renderedHtml).toContain('<th>Score</th>');
+	});
+
+	test('builds plain-text excerpt previews from markdown excerpts', async () => {
+		await expect(
+			getExcerptPreview(
+				'I got a [Pebble](http://getpebble.com/) smartwatch a little over a week ago.',
+				240,
+			),
+		).resolves.toBe('I got a Pebble smartwatch a little over a week ago.');
 	});
 });
 


### PR DESCRIPTION
## Summary
- run excerpt previews through the markdown pipeline before collapsing them to teaser text
- keep the existing preview truncation behavior while removing raw markdown syntax from cards
- add a regression test covering markdown links in excerpts

## Testing
- npm test -- --run src/markdown-and-routing.test.js
- npm run build
