### PR TITLE
fix: restore excerpt preview build

### DIFF
--- a/src/lib/excerpt-preview.js
+++ b/src/lib/excerpt-preview.js
@@ -6,6 +6,7 @@ import { rehypeCindorCodeBlocks } from './astro-markdown/rehypeCindorCodeBlocks.
 import { remarkLegacyContainers } from './astro-markdown/remarkLegacyContainers.mjs';
 
 const decodeHtmlEntities = (value) =>
+	String(value)
 		.replace(/&nbsp;/gi, ' ')
 		.replace(/&amp;/gi, '&')
 		.replace(/&lt;/gi, '<')


### PR DESCRIPTION
## Summary
- restore the missing `String(value)` receiver in `decodeHtmlEntities`
- fix the syntax error causing Astro/Vite builds to fail on Netlify

## Verification
- `npm test -- --run src/markdown-and-routing.test.js`
- `npm run build`
