### PR TITLE
Potential fix for code scanning alert no. 15: Double escaping or unescaping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6306,6 +6306,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6326,6 +6327,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6346,6 +6348,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6366,6 +6369,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6386,6 +6390,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6406,6 +6411,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6426,6 +6432,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6446,6 +6453,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6466,6 +6474,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6486,6 +6495,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -6506,6 +6516,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/lib/excerpt-preview.js
+++ b/src/lib/excerpt-preview.js
@@ -7,11 +7,17 @@ import { remarkLegacyContainers } from './astro-markdown/remarkLegacyContainers.
 
 const decodeHtmlEntities = (value) =>
 	String(value)
+		.replace(/&amp;nbsp;/gi, ' ')
+		.replace(/&amp;lt;/gi, '<')
+		.replace(/&amp;gt;/gi, '>')
+		.replace(/&amp;quot;/gi, '"')
+		.replace(/&amp;(?:#39|apos);/gi, "'")
 		.replace(/&nbsp;/gi, ' ')
 		.replace(/&lt;/gi, '<')
 		.replace(/&gt;/gi, '>')
 		.replace(/&quot;/gi, '"')
 		.replace(/&#39;|&apos;/gi, "'")
+		.replace(/&amp;amp;/gi, '&')
 		.replace(/&amp;/gi, '&');
 
 const stripHtml = (value = '') =>

--- a/src/lib/excerpt-preview.js
+++ b/src/lib/excerpt-preview.js
@@ -8,11 +8,11 @@ import { remarkLegacyContainers } from './astro-markdown/remarkLegacyContainers.
 const decodeHtmlEntities = (value) =>
 	String(value)
 		.replace(/&nbsp;/gi, ' ')
-		.replace(/&amp;/gi, '&')
 		.replace(/&lt;/gi, '<')
 		.replace(/&gt;/gi, '>')
 		.replace(/&quot;/gi, '"')
-		.replace(/&#39;|&apos;/gi, "'");
+		.replace(/&#39;|&apos;/gi, "'")
+		.replace(/&amp;/gi, '&');
 
 const stripHtml = (value = '') =>
 	decodeHtmlEntities(

--- a/src/markdown-and-routing.test.js
+++ b/src/markdown-and-routing.test.js
@@ -99,6 +99,18 @@ describe('Astro markdown pipeline', () => {
 			),
 		).resolves.toBe('I got a Pebble smartwatch a little over a week ago.');
 	});
+
+	test('decodes HTML entities in excerpt previews', async () => {
+		await expect(
+			getExcerptPreview('She said &quot;hello&quot; and wasn&apos;t sure.&nbsp;Really.', 240),
+		).resolves.toBe("She said \"hello\" and wasn't sure. Really.");
+	});
+
+	test('does not decode double-escaped entities into HTML-significant characters', async () => {
+		await expect(
+			getExcerptPreview('Text with &amp;amp; and &amp;lt;b&gt; inside.', 240),
+		).resolves.not.toContain('<b>');
+	});
 });
 
 describe('HTML conversion helpers', () => {


### PR DESCRIPTION
Potential fix for [https://github.com/cbulock/ct4/security/code-scanning/15](https://github.com/cbulock/ct4/security/code-scanning/15)

To fix this safely without changing intended functionality, decode `&amp;` last.  
General rule: when **escaping**, escape `&` first; when **unescaping**, decode `&amp;` last.

In `src/lib/excerpt-preview.js`, update `decodeHtmlEntities` so replacements for `&nbsp;`, `&lt;`, `&gt;`, `&quot;`, and `&#39;|&apos;` happen first, and move `.replace(/&amp;/gi, '&')` to the end of the chain. No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
